### PR TITLE
config: add default value for Jout parameter

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,6 +46,7 @@ var	Default_config  configuration = configuration{
 	Mode:		PRINT_SUBSYS,
 	Excluded:	[]string{"rcu_.*"},
 	MaxDepth:	0,		//0: no limit
+	Jout:       "GraphOnly",
 	}
 
 func push_cmd_line_item(Switch string, Help_str string, Has_arg bool, Needed bool, Func Arg_func, cmd_line *[]cmd_line_items){


### PR DESCRIPTION
This PR sets the default value for the 'Jout' configuration parameter to "GraphOnly".