### PR TITLE
Rename according to GO standards

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,9 +11,18 @@ These are mostly guidelines, not rules.
 Use your best judgment, and feel free to propose changes to 
 the code in a pull request.
 
-# bug and new features
+# Bugs and new features
 
 I intend to keep everything easy and track features and bugs 
-by using the github infrastructure.
-If you have issues or you want to purpose a new feature, feel 
+by using the GitHub infrastructure.
+If you have issues or if you want to purpose a new feature, feel 
 free to just open issue or a pull request.
+
+# Opening a PR
+
+To ensure that the code base stays clean and consistent, we are adhering to the following 
+rules:
+
+* Follow Go conventions where applicable (e.g. naming using camelCase or PascalCase)
+* Use `go fmt` to format the code 
+* Linting rules TBA

--- a/config.go
+++ b/config.go
@@ -106,21 +106,21 @@ func cmdLineItemInit() []cmdLineItems {
 	var res []cmdLineItems
 
 	pushCmdLineItem("-j", "Force Json output with subsystems data", true, false, funcOutType, &res)
-	pushCmdLineItem("-s", "Specifies Symbol", true, true, funcSymbol, &res)
-	pushCmdLineItem("-i", "Specifies Instance", true, true, funcInstance, &res)
+	pushCmdLineItem("-s", "Specifies symbol", true, true, funcSymbol, &res)
+	pushCmdLineItem("-i", "Specifies instance", true, true, funcInstance, &res)
 	pushCmdLineItem("-f", "Specifies config file", true, false, funcJconf, &res)
 	pushCmdLineItem("-u", "Forces use specified database userid", true, false, funcDBUser, &res)
 	pushCmdLineItem("-p", "Forces use specified password", true, false, funcDBPass, &res)
 	pushCmdLineItem("-d", "Forces use specified DBHost", true, false, funcDBHost, &res)
 	pushCmdLineItem("-p", "Forces use specified DBPort", true, false, funcDBPort, &res)
-	pushCmdLineItem("-m", "Sets display Mode 2=subsystems,1=all", true, false, funcMode, &res)
-	pushCmdLineItem("-h", "This Help", false, false, funcHelp, &res)
+	pushCmdLineItem("-m", "Sets display mode 2=subsystems,1=all", true, false, funcMode, &res)
+	pushCmdLineItem("-h", "This help", false, false, funcHelp, &res)
 
 	return res
 }
 
 func funcHelp(conf *configuration, fn []string) error {
-	return errors.New("command Help")
+	return errors.New("command help")
 }
 
 func funcOutType(conf *configuration, JOut []string) error {
@@ -186,7 +186,7 @@ func funcMode(conf *configuration, mode []string) error {
 		return err
 	}
 	if s < 1 || s > 2 {
-		return errors.New("unsupported Mode")
+		return errors.New("unsupported mode")
 	}
 	(*conf).Mode = s
 	return nil

--- a/config.go
+++ b/config.go
@@ -1,267 +1,268 @@
-	/*
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 *
-	 *   Name: nav - Kernel source code analysis tool
-	 *   Description: Extract call trees for kernel API
-	 *
-	 *   Author: Alessandro Carminati <acarmina@redhat.com>
-	 *   Author: Maurizio Papini <mpapini@redhat.com>
-	 *
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 *
-	 *   Copyright (c) 2022 Red Hat, Inc. All rights reserved.
-	 *
-	 *   This copyrighted material is made available to anyone wishing
-	 *   to use, modify, copy, or redistribute it subject to the terms
-	 *   and conditions of the GNU General Public License version 2.
-	 *
-	 *   This program is distributed in the hope that it will be
-	 *   useful, but WITHOUT ANY WARRANTY; without even the implied
-	 *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-	 *   PURPOSE. See the GNU General Public License for more details.
-	 *
-	 *   You should have received a copy of the GNU General Public
-	 *   License along with this program; if not, write to the Free
-	 *   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-	 *   Boston, MA 02110-1301, USA.
-	 *
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 */
+/*
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ *   Name: nav - Kernel source code analysis tool
+ *   Description: Extract call trees for kernel API
+ *
+ *   Author: Alessandro Carminati <acarmina@redhat.com>
+ *   Author: Maurizio Papini <mpapini@redhat.com>
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ *   Copyright (c) 2022 Red Hat, Inc. All rights reserved.
+ *
+ *   This copyrighted material is made available to anyone wishing
+ *   to use, modify, copy, or redistribute it subject to the terms
+ *   and conditions of the GNU General Public License version 2.
+ *
+ *   This program is distributed in the hope that it will be
+ *   useful, but WITHOUT ANY WARRANTY; without even the implied
+ *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE. See the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public
+ *   License along with this program; if not, write to the Free
+ *   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *   Boston, MA 02110-1301, USA.
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
 
 package main
 
 import (
-	"strconv"
-	"fmt"
-	"os"
-	"errors"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io/ioutil"
-	)
+	"os"
+	"strconv"
+)
 
-var conf_fn = "conf.json"
+var confFn = "conf.json"
 
-const app_name	string="App Name: nav"
+const (
+	appName  string = "App Name: nav"
+	appDescr string = "Description: kernel Symbol navigator"
+)
 
-const app_descr	string="Descr: kernel symbol navigator"
-
-type Arg_func func(*configuration, []string) (error)
+type argFunc func(*configuration, []string) error
 
 // Command line switch elements
-type cmd_line_items struct {
-	id		int
-	Switch		string
-	Help_srt	string
-	Has_arg		bool
-	Needed		bool
-	Func		Arg_func
+type cmdLineItems struct {
+	id        int
+	switchStr string
+	helpStr   string
+	hasArg    bool
+	needed    bool
+	function  argFunc
 }
 
 // Represents the application configuration
 type configuration struct {
-	DBURL		string
-	DBPort		int
-	DBUser		string
-	DBPassword	string
-	DBTargetDB	string
-	Symbol		string
-	Instance	int
-	Mode		int
-	Excluded	[]string
-	MaxDepth	uint
-	Jout		string
-	cmdlineNeeds	map[string] bool
+	DBURL        string
+	DBPort       int
+	DBUser       string
+	DBPassword   string
+	DBTargetDB   string
+	Symbol       string
+	Instance     int
+	Mode         int
+	Excluded     []string
+	MaxDepth     uint
+	Jout         string
+	cmdlineNeeds map[string]bool
 }
 
 // Instance of default configuration values
-var	Default_config  configuration = configuration{
-	DBURL:		"dbs.hqhome163.com",
-	DBPort:		5432,
-	DBUser:		"alessandro",
-	DBPassword:	"<password>",
-	DBTargetDB:	"kernel_bin",
-	Symbol:		"",
-	Instance:	0,
-	Mode:		PRINT_SUBSYS,
-	Excluded:	[]string{"rcu_.*"},
-	MaxDepth:	0,		//0: no limit
-	Jout:		"GraphOnly",
-	cmdlineNeeds:	map[string] bool{},
-	}
+var defaultConfig configuration = configuration{
+	DBURL:        "dbs.hqhome163.com",
+	DBPort:       5432,
+	DBUser:       "alessandro",
+	DBPassword:   "<password>",
+	DBTargetDB:   "kernel_bin",
+	Symbol:       "",
+	Instance:     0,
+	Mode:         printSubsys,
+	Excluded:     []string{"rcu_.*"},
+	MaxDepth:     0, //0: no limit
+	Jout:         "graphOnly",
+	cmdlineNeeds: map[string]bool{},
+}
 
-// Inserts a commandline item item, which is composed by:
+// Inserts a commandline item, which is composed by:
 // * switch string
-// * switch descriptio
-// * if the switch requires an additiona argument
+// * switch description
+// * if the switch requires an additional argument
 // * a pointer to the function that manages the switch
 // * the configuration that gets updated
-func push_cmd_line_item(Switch string, Help_str string, Has_arg bool, Needed bool, Func Arg_func, cmd_line *[]cmd_line_items){
-	*cmd_line = append(*cmd_line, cmd_line_items{id: len(*cmd_line)+1, Switch: Switch, Help_srt: Help_str, Has_arg: Has_arg, Needed: Needed, Func: Func})
+func pushCmdLineItem(switchStr string, helpStr string, hasArg bool, needed bool, function argFunc, cmdLine *[]cmdLineItems) {
+	*cmdLine = append(*cmdLine, cmdLineItems{id: len(*cmdLine) + 1, switchStr: switchStr, helpStr: helpStr, hasArg: hasArg, needed: needed, function: function})
 }
 
 // This function initializes configuration parser subsystem
-// Inserts all the commandline switches suppported by the application
-func cmd_line_item_init() ([]cmd_line_items){
-	var res	[]cmd_line_items
+// Inserts all the commandline switches supported by the application
+func cmdLineItemInit() []cmdLineItems {
+	var res []cmdLineItems
 
-	push_cmd_line_item("-j", "Force Json output with subsystems data",	true,  false,	func_outtype,	&res)
-	push_cmd_line_item("-s", "Specifies symbol",				true,  true,	func_symbol,	&res)
-	push_cmd_line_item("-i", "Specifies instance",				true,  true,	func_instance,	&res)
-	push_cmd_line_item("-f", "Specifies config file",			true,  false,	func_jconf,	&res)
-	push_cmd_line_item("-u", "Forces use specified database userid",	true,  false,	func_DBUser,	&res)
-	push_cmd_line_item("-p", "Forecs use specified password",		true,  false,	func_DBPass,	&res)
-	push_cmd_line_item("-d", "Forecs use specified DBhost",			true,  false,	func_DBHost,	&res)
-	push_cmd_line_item("-p", "Forecs use specified DBPort",			true,  false,	func_DBPort,	&res)
-	push_cmd_line_item("-m", "Sets display mode 2=subsystems,1=all",	true,  false,	func_Mode,	&res)
-	push_cmd_line_item("-h", "This Help",					false, false,	func_help,	&res)
+	pushCmdLineItem("-j", "Force Json output with subsystems data", true, false, funcOutType, &res)
+	pushCmdLineItem("-s", "Specifies Symbol", true, true, funcSymbol, &res)
+	pushCmdLineItem("-i", "Specifies Instance", true, true, funcInstance, &res)
+	pushCmdLineItem("-f", "Specifies config file", true, false, funcJconf, &res)
+	pushCmdLineItem("-u", "Forces use specified database userid", true, false, funcDBUser, &res)
+	pushCmdLineItem("-p", "Forces use specified password", true, false, funcDBPass, &res)
+	pushCmdLineItem("-d", "Forces use specified DBHost", true, false, funcDBHost, &res)
+	pushCmdLineItem("-p", "Forces use specified DBPort", true, false, funcDBPort, &res)
+	pushCmdLineItem("-m", "Sets display Mode 2=subsystems,1=all", true, false, funcMode, &res)
+	pushCmdLineItem("-h", "This Help", false, false, funcHelp, &res)
 
 	return res
 }
 
-func func_help		(conf *configuration,fn []string)		(error){
-	return errors.New("Command Help")
+func funcHelp(conf *configuration, fn []string) error {
+	return errors.New("command Help")
 }
 
-func func_outtype(conf *configuration, jout []string)			(error){
-	(*conf).Jout=jout[0]
+func funcOutType(conf *configuration, JOut []string) error {
+	(*conf).Jout = JOut[0]
 	return nil
 }
 
-func func_jconf		(conf *configuration,fn []string)		(error){
+func funcJconf(conf *configuration, fn []string) error {
 	jsonFile, err := os.Open(fn[0])
 	if err != nil {
 		return err
-		}
+	}
 	byteValue, _ := ioutil.ReadAll(jsonFile)
 	jsonFile.Close()
-	err=json.Unmarshal(byteValue, conf)
+	err = json.Unmarshal(byteValue, conf)
 	if err != nil {
 		return err
-		}
+	}
 	return nil
 }
 
-func func_symbol	(conf *configuration, fn []string)	(error){
-	(*conf).Symbol=fn[0]
+func funcSymbol(conf *configuration, fn []string) error {
+	(*conf).Symbol = fn[0]
 	return nil
 }
 
-func func_DBUser	(conf *configuration, user []string)	(error){
-	(*conf).DBUser=user[0]
+func funcDBUser(conf *configuration, user []string) error {
+	(*conf).DBUser = user[0]
 	return nil
 }
 
-func func_DBPass	(conf *configuration, pass []string)	(error){
-	(*conf).DBPassword=pass[0]
+func funcDBPass(conf *configuration, pass []string) error {
+	(*conf).DBPassword = pass[0]
 	return nil
 }
 
-func func_DBHost	(conf *configuration, host []string)	(error){
-	(*conf).DBURL=host[0]
+func funcDBHost(conf *configuration, host []string) error {
+	(*conf).DBURL = host[0]
 	return nil
 }
 
-func func_DBPort	(conf *configuration, port []string)	(error){
+func funcDBPort(conf *configuration, port []string) error {
 	s, err := strconv.Atoi(port[0])
-	if err!=nil {
+	if err != nil {
 		return err
-		}
-	(*conf).DBPort=s
+	}
+	(*conf).DBPort = s
 	return nil
 }
 
-func func_instance	(conf *configuration, instance []string)    (error){
+func funcInstance(conf *configuration, instance []string) error {
 	s, err := strconv.Atoi(instance[0])
-	if err!=nil {
+	if err != nil {
 		return err
-		}
-	(*conf).Instance=s
+	}
+	(*conf).Instance = s
 	return nil
 }
 
-func func_Mode		(conf *configuration, mode []string)    (error){
+func funcMode(conf *configuration, mode []string) error {
 	s, err := strconv.Atoi(mode[0])
-	if err!=nil {
+	if err != nil {
 		return err
-		}
-	if s<1 || s>2 {
-		return errors.New("unsupported mode")
-		}
-	(*conf).Mode=s
+	}
+	if s < 1 || s > 2 {
+		return errors.New("unsupported Mode")
+	}
+	(*conf).Mode = s
 	return nil
 }
 
 // Uses commandline args to generate the help string
-func print_help(lines []cmd_line_items){
+func printHelp(lines []cmdLineItems) {
 
-	fmt.Println(app_name)
-	fmt.Println(app_descr)
-	for _,item := range lines{
+	fmt.Println(appName)
+	fmt.Println(appDescr)
+	for _, item := range lines {
 		fmt.Printf(
 			"\t%s\t%s\t%s\n",
-			item.Switch,
-			func (a bool)(string){
+			item.switchStr,
+			func(a bool) string {
 				if a {
 					return "<v>"
-					}
+				}
 				return ""
-			}(item.Has_arg),
-			item.Help_srt,
-			)
-		}
+			}(item.hasArg),
+			item.helpStr,
+		)
+	}
 }
 
 // Used to parse the command line and generate the command line
-func args_parse(lines []cmd_line_items)(configuration, error){
-	var	extra		bool=false;
-	var	conf		configuration=Default_config
-	var 	f		Arg_func
+func argsParse(lines []cmdLineItems) (configuration, error) {
+	var extra bool = false
+	var conf configuration = defaultConfig
+	var f argFunc
 
-	for _, item := range lines{
-		if item.Needed {
-			conf.cmdlineNeeds[item.Switch]=false
-			}
+	for _, item := range lines {
+		if item.needed {
+			conf.cmdlineNeeds[item.switchStr] = false
 		}
+	}
 
-	for _, os_arg := range os.Args[1:] {
+	for _, OSArg := range os.Args[1:] {
 		if !extra {
-			for _, arg := range lines{
-				if arg.Switch==os_arg {
-					if arg.Needed {
-						conf.cmdlineNeeds[arg.Switch]=true
-						}
-					if arg.Has_arg{
-						f=arg.Func
-						extra=true
+			for _, arg := range lines {
+				if arg.switchStr == OSArg {
+					if arg.needed {
+						conf.cmdlineNeeds[arg.switchStr] = true
+					}
+					if arg.hasArg {
+						f = arg.function
+						extra = true
 						break
-						}
-					err := arg.Func(&conf, []string{})
+					}
+					err := arg.function(&conf, []string{})
 					if err != nil {
-						return Default_config, err
-						}
+						return defaultConfig, err
 					}
 				}
+			}
 			continue
-			}
-		if extra{
-			err := f(&conf,[]string{os_arg})
+		}
+		if extra {
+			err := f(&conf, []string{OSArg})
 			if err != nil {
-				return Default_config, err
-				}
-			extra=false
+				return defaultConfig, err
 			}
-
+			extra = false
 		}
+
+	}
 	if extra {
-		 return  Default_config, errors.New("Missing switch arg")
-		}
+		return defaultConfig, errors.New("missing switch arg")
+	}
 
-	res:=true
+	res := true
 	for _, element := range conf.cmdlineNeeds {
 		res = res && element
-		}
+	}
 	if res {
-		return	conf, nil
-		}
-	return Default_config, errors.New("Missing needed arg")
+		return conf, nil
+	}
+	return defaultConfig, errors.New("missing needed arg")
 }

--- a/main_test.go
+++ b/main_test.go
@@ -83,25 +83,25 @@ func TestConfig(t *testing.T) {
 	}
 
 	if !compareConfigs(conf, defaultConfig) {
-		t.Error("unexpected change in default config")
+		t.Error("Unexpected change in default config")
 	}
 
 	os.Args = []string{"nav", "-i", "1", "-s"}
 	conf, err = argsParse(cmdLineItemInit())
 	if err == nil {
-		t.Error("error Missing switch argument not detected", conf)
+		t.Error("Missing switch argument not detected", conf)
 	}
 
 	os.Args = []string{"nav", "-i", "a", "-s", "symb"}
 	conf, err = argsParse(cmdLineItemInit())
 	if err == nil {
-		t.Error("error switch arg type mismatch not detected", conf)
+		t.Error("Switch arg type mismatch not detected", conf)
 	}
 
 	os.Args = []string{"nav", "-i", "a", "-s", "symb", "-f"}
 	conf, err = argsParse(cmdLineItemInit())
 	if err == nil {
-		t.Error("error Missing optional switch argument not detected", conf)
+		t.Error("Missing optional switch argument not detected", conf)
 	}
 
 	_, filename, _, _ := runtime.Caller(0)
@@ -110,10 +110,10 @@ func TestConfig(t *testing.T) {
 	os.Args = []string{"nav", "-i", "1", "-s", "symb", "-f", current + "/t_files/dummy.json"}
 	conf, err = argsParse(cmdLineItemInit())
 	if err == nil {
-		t.Error("undetected missing file", conf)
+		t.Error("Undetected missing file", conf)
 	}
 	if !compareConfigs(conf, defaultConfig) {
-		t.Error("unexpected change in default config")
+		t.Error("Unexpected change in default config")
 	}
 
 	os.Args = []string{"nav", "-i", "1", "-s", "symb", "-f", current + "/t_files/test1.json"}
@@ -122,7 +122,7 @@ func TestConfig(t *testing.T) {
 		t.Error("Unexpected conf error while reading from existing file", err, current+"/t_files/test1.json")
 	}
 	if !compareConfigs(conf, TestConfig) {
-		t.Error("unexpected difference between actual and loaded config", conf, TestConfig)
+		t.Error("Unexpected difference between actual and loaded config", conf, TestConfig)
 	}
 
 	tmp := TestConfig
@@ -133,7 +133,7 @@ func TestConfig(t *testing.T) {
 		t.Error("Unexpected conf error while reading from existing file", err, current+"/t_files/test1.json")
 	}
 	if !compareConfigs(conf, tmp) {
-		t.Error("unexpected difference between actual and loaded modified config", conf, TestConfig)
+		t.Error("Unexpected difference between actual and loaded modified config", conf, TestConfig)
 	}
 
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,46 +1,46 @@
-	/*
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 *
-	 *   Name: nav - Kernel source code analysis tool
-	 *   Description: Extract call trees for kernel API
-	 *
-	 *   Author: Alessandro Carminati <acarmina@redhat.com>
-	 *   Author: Maurizio Papini <mpapini@redhat.com>
-	 *
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 *
-	 *   Copyright (c) 2022 Red Hat, Inc. All rights reserved.
-	 *
-	 *   This copyrighted material is made available to anyone wishing
-	 *   to use, modify, copy, or redistribute it subject to the terms
-	 *   and conditions of the GNU General Public License version 2.
-	 *
-	 *   This program is distributed in the hope that it will be
-	 *   useful, but WITHOUT ANY WARRANTY; without even the implied
-	 *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-	 *   PURPOSE. See the GNU General Public License for more details.
-	 *
-	 *   You should have received a copy of the GNU General Public
-	 *   License along with this program; if not, write to the Free
-	 *   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-	 *   Boston, MA 02110-1301, USA.
-	 *
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 */
+/*
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ *   Name: nav - Kernel source code analysis tool
+ *   Description: Extract call trees for kernel API
+ *
+ *   Author: Alessandro Carminati <acarmina@redhat.com>
+ *   Author: Maurizio Papini <mpapini@redhat.com>
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ *   Copyright (c) 2022 Red Hat, Inc. All rights reserved.
+ *
+ *   This copyrighted material is made available to anyone wishing
+ *   to use, modify, copy, or redistribute it subject to the terms
+ *   and conditions of the GNU General Public License version 2.
+ *
+ *   This program is distributed in the hope that it will be
+ *   useful, but WITHOUT ANY WARRANTY; without even the implied
+ *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE. See the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public
+ *   License along with this program; if not, write to the Free
+ *   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *   Boston, MA 02110-1301, USA.
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
 
 package main
 
 import (
-	"testing"
-	"path/filepath"
 	"os"
+	"path/filepath"
 	"runtime"
-	)
+	"testing"
+)
 
-// Utility function to compart two configuration struct instances
-func Compare_configs(c1 configuration, c2 configuration) (bool){
+// Utility function to compare two configuration struct instances
+func compareConfigs(c1 configuration, c2 configuration) bool {
 
-	res:=true
+	res := true
 	res = res && c1.DBURL == c2.DBURL
 	res = res && c1.DBPort == c2.DBPort
 	res = res && c1.DBUser == c2.DBUser
@@ -54,87 +54,86 @@ func Compare_configs(c1 configuration, c2 configuration) (bool){
 	res = res && len(c1.Excluded) == len(c2.Excluded)
 	for i, item := range c1.Excluded {
 		res = res && item == c2.Excluded[i]
-		}
+	}
 	return res
 }
 
 // Tests the ability to extract the configuration from command line arguments
-func TestConfig(t *testing.T){
+func TestConfig(t *testing.T) {
 
-var     Test_config  configuration = configuration{
-        DBURL:          "dummy",
-        DBPort:         1234,
-        DBUser:         "dummy",
-        DBPassword:     "dummy",
-        DBTargetDB:     "dummy",
-        Symbol:         "dummy",
-        Instance:       1234,
-        Mode:           1234,
-        Excluded:       []string{"dummy1", "dummy2", "dummy3"},
-        MaxDepth:       1234,              //0: no limit
-        Jout:           "JsonOutputPlain",
-        cmdlineNeeds:   map[string] bool{},
-        }
+	var TestConfig configuration = configuration{
+		DBURL:        "dummy",
+		DBPort:       1234,
+		DBUser:       "dummy",
+		DBPassword:   "dummy",
+		DBTargetDB:   "dummy",
+		Symbol:       "dummy",
+		Instance:     1234,
+		Mode:         1234,
+		Excluded:     []string{"dummy1", "dummy2", "dummy3"},
+		MaxDepth:     1234, //0: no limit
+		Jout:         "JsonOutputPlain",
+		cmdlineNeeds: map[string]bool{},
+	}
 
-
-	os.Args=[]string{"nav"}
-	conf, err := args_parse(cmd_line_item_init())
-	if err==nil {
+	os.Args = []string{"nav"}
+	conf, err := argsParse(cmdLineItemInit())
+	if err == nil {
 		t.Error("Error validating empty command line input against mandatory args")
-		}
+	}
 
-	if !Compare_configs(conf, Default_config) {
+	if !compareConfigs(conf, defaultConfig) {
 		t.Error("unexpected change in default config")
-		}
+	}
 
-	os.Args=[]string{"nav", "-i", "1", "-s"}
-        conf, err = args_parse(cmd_line_item_init())
-	if err==nil {
+	os.Args = []string{"nav", "-i", "1", "-s"}
+	conf, err = argsParse(cmdLineItemInit())
+	if err == nil {
 		t.Error("error Missing switch argument not detected", conf)
-		}
+	}
 
-	os.Args=[]string{"nav", "-i", "a", "-s", "symb"}
-        conf, err = args_parse(cmd_line_item_init())
-	if err==nil {
+	os.Args = []string{"nav", "-i", "a", "-s", "symb"}
+	conf, err = argsParse(cmdLineItemInit())
+	if err == nil {
 		t.Error("error switch arg type mismatch not detected", conf)
-		}
+	}
 
-	os.Args=[]string{"nav", "-i", "a", "-s", "symb", "-f", }
-        conf, err = args_parse(cmd_line_item_init())
-	if err==nil {
+	os.Args = []string{"nav", "-i", "a", "-s", "symb", "-f"}
+	conf, err = argsParse(cmdLineItemInit())
+	if err == nil {
 		t.Error("error Missing optional switch argument not detected", conf)
-		}
+	}
 
 	_, filename, _, _ := runtime.Caller(0)
 	current := filepath.Dir(filename)
 
-	os.Args=[]string{"nav", "-i", "1", "-s", "symb", "-f", current+"/t_files/dummy.json"}
-        conf, err = args_parse(cmd_line_item_init())
-	if err==nil {
+	os.Args = []string{"nav", "-i", "1", "-s", "symb", "-f", current + "/t_files/dummy.json"}
+	conf, err = argsParse(cmdLineItemInit())
+	if err == nil {
 		t.Error("undetected missing file", conf)
-		}
-	if !Compare_configs(conf, Default_config) {
+	}
+	if !compareConfigs(conf, defaultConfig) {
 		t.Error("unexpected change in default config")
-		}
+	}
 
-	os.Args=[]string{"nav", "-i", "1", "-s", "symb", "-f", current+"/t_files/test1.json"}
-        conf, err = args_parse(cmd_line_item_init())
-	if err!=nil {
+	os.Args = []string{"nav", "-i", "1", "-s", "symb", "-f", current + "/t_files/test1.json"}
+	conf, err = argsParse(cmdLineItemInit())
+	if err != nil {
 		t.Error("Unexpected conf error while reading from existing file", err, current+"/t_files/test1.json")
-		}
-	if !Compare_configs(conf, Test_config) {
-		t.Error("unexpected difference between actual and loaded config", conf, Test_config)
-		}
+	}
+	if !compareConfigs(conf, TestConfig) {
+		t.Error("unexpected difference between actual and loaded config", conf, TestConfig)
+	}
 
-	tmp:=Test_config
-	tmp.DBUser="new"
-	os.Args=[]string{"nav", "-i", "1", "-s", "symb", "-f", current+"/t_files/test1.json", "-u", "new"}
-        conf, err = args_parse(cmd_line_item_init())
-	if err!=nil {
+	tmp := TestConfig
+	tmp.DBUser = "new"
+	os.Args = []string{"nav", "-i", "1", "-s", "symb", "-f", current + "/t_files/test1.json", "-u", "new"}
+	conf, err = argsParse(cmdLineItemInit())
+	if err != nil {
 		t.Error("Unexpected conf error while reading from existing file", err, current+"/t_files/test1.json")
-		}
-	if !Compare_configs(conf, tmp) {
-		t.Error("unexpected difference between actual and loaded modified config", conf, Test_config)
-		}
+	}
+	if !compareConfigs(conf, tmp) {
+		t.Error("unexpected difference between actual and loaded modified config", conf, TestConfig)
+	}
 
 }

--- a/nav.go
+++ b/nav.go
@@ -92,14 +92,14 @@ func generateOutput(db *sql.DB, conf *configuration) (string, error) {
 
 	start, err := sym2num(db, (*conf).Symbol, (*conf).Instance)
 	if err != nil {
-		fmt.Println("Symbol not found")
+		fmt.Println("symbol not found")
 		return "", err
 	}
 
 	graphOutput = fmtDotHeader[opt2num((*conf).Jout)]
 	entry, err := getEntryByID(db, start, (*conf).Instance, cache2)
 	if err != nil {
-		entryName = "Unknown"
+		entryName = "unknown"
 		return "", err
 	} else {
 		entryName = entry.symbol
@@ -136,7 +136,7 @@ func generateOutput(db *sql.DB, conf *configuration) (string, error) {
 		jsonOutput = fmt.Sprintf(jsonOutputFMT, b64dot, (*conf).Jout, symbdata)
 
 	default:
-		return "", errors.New("unknown output Mode")
+		return "", errors.New("unknown output mode")
 	}
 	return jsonOutput, nil
 }

--- a/nav.go
+++ b/nav.go
@@ -1,169 +1,168 @@
-	/*
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 *
-	 *   Name: nav - Kernel source code analysis tool
-	 *   Description: Extract call trees for kernel API
-	 *
-	 *   Author: Alessandro Carminati <acarmina@redhat.com>
-	 *   Author: Maurizio Papini <mpapini@redhat.com>
-	 *
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 *
-	 *   Copyright (c) 2022 Red Hat, Inc. All rights reserved.
-	 *
-	 *   This copyrighted material is made available to anyone wishing
-	 *   to use, modify, copy, or redistribute it subject to the terms
-	 *   and conditions of the GNU General Public License version 2.
-	 *
-	 *   This program is distributed in the hope that it will be
-	 *   useful, but WITHOUT ANY WARRANTY; without even the implied
-	 *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-	 *   PURPOSE. See the GNU General Public License for more details.
-	 *
-	 *   You should have received a copy of the GNU General Public
-	 *   License along with this program; if not, write to the Free
-	 *   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-	 *   Boston, MA 02110-1301, USA.
-	 *
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 */
+/*
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ *   Name: nav - Kernel source code analysis tool
+ *   Description: Extract call trees for kernel API
+ *
+ *   Author: Alessandro Carminati <acarmina@redhat.com>
+ *   Author: Maurizio Papini <mpapini@redhat.com>
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ *   Copyright (c) 2022 Red Hat, Inc. All rights reserved.
+ *
+ *   This copyrighted material is made available to anyone wishing
+ *   to use, modify, copy, or redistribute it subject to the terms
+ *   and conditions of the GNU General Public License version 2.
+ *
+ *   This program is distributed in the hope that it will be
+ *   useful, but WITHOUT ANY WARRANTY; without even the implied
+ *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE. See the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public
+ *   License along with this program; if not, write to the Free
+ *   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *   Boston, MA 02110-1301, USA.
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
 
 package main
 
 import (
 	"bytes"
 	"compress/gzip"
+	"database/sql"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
-	"database/sql"
-	"encoding/base64"
-	)
+)
 
 const (
-	GraphOnly int		= 1
-	JsonOutputPlain int	= 2
-	JsonOutputB64 int	= 3
-	JsonOutputGZB64 int	= 4
-	)
+	graphOnly       int    = 1
+	jsonOutputPlain int    = 2
+	jsonOutputB64   int    = 3
+	jsonOutputGZB64 int    = 4
+	jsonOutputFMT   string = "{\"graph\": \"%s\",\"graph_type\":\"%s\",\"symbols\": [%s]}"
+)
 
-const JsonOutputFMT string = "{\"graph\": \"%s\",\"graph_type\":\"%s\",\"symbols\": [%s]}"
-
-var fmt_dot = []string {
-		"",
-		"\"%s\"->\"%s\" \n",
-		"\\\"%s\\\"->\\\"%s\\\" \\\\\\n",
-		"\"%s\"->\"%s\" \n",
-		"\"%s\"->\"%s\" \n",
-		}
-
-var fmt_dot_header = []string {
-		"",
-		"digraph G {\n",
-		"digraph G {\\\\\\n",
-		"digraph G {\n",
-		"digraph G {\n",
-		}
-
-func opt2num(s string) int{
-        var opt = map[string]int{
-                "GraphOnly":1,
-                "JsonOutputPlain":2,
-                "JsonOutputB64":3,
-                "JsonOutputGZB64":4,
-                }
-        val, ok := opt[s]
-        if !ok {
-                return 0
-        }
-        return val
+var fmtDot = []string{
+	"",
+	"\"%s\"->\"%s\" \n",
+	"\\\"%s\\\"->\\\"%s\\\" \\\\\\n",
+	"\"%s\"->\"%s\" \n",
+	"\"%s\"->\"%s\" \n",
 }
 
-func generate_output(db *sql.DB, conf *configuration) (string, error){
-	var	GraphOutput	string
-	var 	JsonOutput	string
-	var	prod =		map[string]int{}
-	var	visited		[]int
-	var	entry_name	string
-	var	output		string
+var fmtDotHeader = []string{
+	"",
+	"digraph G {\n",
+	"digraph G {\\\\\\n",
+	"digraph G {\n",
+	"digraph G {\n",
+}
 
-	cache := make(map[int][]Entry)
-	cache2 := make(map[int]Entry)
+func opt2num(s string) int {
+	var opt = map[string]int{
+		"GraphOnly":       1,
+		"JsonOutputPlain": 2,
+		"JsonOutputB64":   3,
+		"JsonOutputGZB64": 4,
+	}
+	val, ok := opt[s]
+	if !ok {
+		return 0
+	}
+	return val
+}
+
+func generateOutput(db *sql.DB, conf *configuration) (string, error) {
+	var graphOutput string
+	var jsonOutput string
+	var prod = map[string]int{}
+	var visited []int
+	var entryName string
+	var output string
+
+	cache1 := make(map[int][]entry)
+	cache2 := make(map[int]entry)
 	cache3 := make(map[string]string)
 
-	start, err:=sym2num(db, (*conf).Symbol, (*conf).Instance)
-	if err!=nil{
-		fmt.Println("symbol not found")
+	start, err := sym2num(db, (*conf).Symbol, (*conf).Instance)
+	if err != nil {
+		fmt.Println("Symbol not found")
 		return "", err
-		}
+	}
 
-	GraphOutput=fmt_dot_header[opt2num((*conf).Jout)]
-	entry, err := get_entry_by_id(db, start, (*conf).Instance, cache2)
-		if err!=nil {
-			entry_name="Unknown";
-			return "",err
-			} else {
-				entry_name=entry.Symbol
-				}
+	graphOutput = fmtDotHeader[opt2num((*conf).Jout)]
+	entry, err := getEntryByID(db, start, (*conf).Instance, cache2)
+	if err != nil {
+		entryName = "Unknown"
+		return "", err
+	} else {
+		entryName = entry.symbol
+	}
 
-	Navigate(db, start, entry_name, &visited, prod, (*conf).Instance, Cache{cache, cache2, cache3}, (*conf).Mode, (*conf).Excluded, 0, (*conf).MaxDepth, fmt_dot[opt2num((*conf).Jout)], &output)
-	GraphOutput=GraphOutput+output
-	GraphOutput=GraphOutput+"}"
+	navigate(db, start, entryName, &visited, prod, (*conf).Instance, cache{cache1, cache2, cache3}, (*conf).Mode, (*conf).Excluded, 0, (*conf).MaxDepth, fmtDot[opt2num((*conf).Jout)], &output)
+	graphOutput = graphOutput + output
+	graphOutput = graphOutput + "}"
 
-	symbdata, err := symbSubsys(db, visited, (*conf).Instance, Cache{cache, cache2, cache3})
-	if err != nil{
-		return "",err
-		}
+	symbdata, err := symbSubsys(db, visited, (*conf).Instance, cache{cache1, cache2, cache3})
+	if err != nil {
+		return "", err
+	}
 
 	switch opt2num((*conf).Jout) {
-		case GraphOnly:
-			JsonOutput=GraphOutput
-		case JsonOutputPlain:
-			JsonOutput=fmt.Sprintf(JsonOutputFMT, GraphOutput, (*conf).Jout, symbdata)
-		case JsonOutputB64:
-			b64dot:=base64.StdEncoding.EncodeToString([]byte(GraphOutput))
-			JsonOutput=fmt.Sprintf(JsonOutputFMT, b64dot, (*conf).Jout, symbdata)
+	case graphOnly:
+		jsonOutput = graphOutput
+	case jsonOutputPlain:
+		jsonOutput = fmt.Sprintf(jsonOutputFMT, graphOutput, (*conf).Jout, symbdata)
+	case jsonOutputB64:
+		b64dot := base64.StdEncoding.EncodeToString([]byte(graphOutput))
+		jsonOutput = fmt.Sprintf(jsonOutputFMT, b64dot, (*conf).Jout, symbdata)
 
-		case JsonOutputGZB64:
-			var b bytes.Buffer
-			gz := gzip.NewWriter(&b)
-			if _, err := gz.Write([]byte(GraphOutput)); err != nil {
-				return "", errors.New("gzip failed")
-				}
-			if err := gz.Close(); err != nil {
-				return "", errors.New("gzip failed")
-				}
-			b64dot:=base64.StdEncoding.EncodeToString(b.Bytes())
-			JsonOutput=fmt.Sprintf(JsonOutputFMT, b64dot, (*conf).Jout, symbdata)
+	case jsonOutputGZB64:
+		var b bytes.Buffer
+		gz := gzip.NewWriter(&b)
+		if _, err := gz.Write([]byte(graphOutput)); err != nil {
+			return "", errors.New("gzip failed")
+		}
+		if err := gz.Close(); err != nil {
+			return "", errors.New("gzip failed")
+		}
+		b64dot := base64.StdEncoding.EncodeToString(b.Bytes())
+		jsonOutput = fmt.Sprintf(jsonOutputFMT, b64dot, (*conf).Jout, symbdata)
 
-		default:
-			return "", errors.New("Unknown output mode")
+	default:
+		return "", errors.New("unknown output Mode")
 	}
-	return JsonOutput, nil
+	return jsonOutput, nil
 }
 
 func main() {
 
-        conf, err := args_parse(cmd_line_item_init())
-        if err!=nil {
-		if err.Error() != "dummy"{
+	conf, err := argsParse(cmdLineItemInit())
+	if err != nil {
+		if err.Error() != "dummy" {
 			fmt.Println(err.Error())
-			}
-                print_help(cmd_line_item_init());
-                os.Exit(-1)
-                }
-	if opt2num(conf.Jout)==0 {
-		fmt.Printf("unknown mode %s\n", conf.Jout)
-		os.Exit(-2)
 		}
-	t:=Connect_token{ conf.DBURL, conf.DBPort,  conf.DBUser, conf.DBPassword, conf.DBTargetDB}
-	db:=Connect_db(&t)
+		printHelp(cmdLineItemInit())
+		os.Exit(-1)
+	}
+	if opt2num(conf.Jout) == 0 {
+		fmt.Printf("unknown Mode %s\n", conf.Jout)
+		os.Exit(-2)
+	}
+	t := connectToken{conf.DBURL, conf.DBPort, conf.DBUser, conf.DBPassword, conf.DBTargetDB}
+	db := connectDB(&t)
 
-	output, err := generate_output(db, &conf)
-	if err!=nil{
+	output, err := generateOutput(db, &conf)
+	if err != nil {
 		fmt.Println("internal error", err)
 		os.Exit(-3)
-		}
+	}
 	fmt.Println(output)
 
 }

--- a/psql.go
+++ b/psql.go
@@ -1,332 +1,330 @@
-	/*
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 *
-	 *   Name: nav - Kernel source code analysis tool
-	 *   Description: Extract call trees for kernel API
-	 *
-	 *   Author: Alessandro Carminati <acarmina@redhat.com>
-	 *   Author: Maurizio Papini <mpapini@redhat.com>
-	 *
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 *
-	 *   Copyright (c) 2022 Red Hat, Inc. All rights reserved.
-	 *
-	 *   This copyrighted material is made available to anyone wishing
-	 *   to use, modify, copy, or redistribute it subject to the terms
-	 *   and conditions of the GNU General Public License version 2.
-	 *
-	 *   This program is distributed in the hope that it will be
-	 *   useful, but WITHOUT ANY WARRANTY; without even the implied
-	 *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-	 *   PURPOSE. See the GNU General Public License for more details.
-	 *
-	 *   You should have received a copy of the GNU General Public
-	 *   License along with this program; if not, write to the Free
-	 *   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-	 *   Boston, MA 02110-1301, USA.
-	 *
-	 * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	 */
+/*
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ *   Name: nav - Kernel source code analysis tool
+ *   Description: Extract call trees for kernel API
+ *
+ *   Author: Alessandro Carminati <acarmina@redhat.com>
+ *   Author: Maurizio Papini <mpapini@redhat.com>
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ *   Copyright (c) 2022 Red Hat, Inc. All rights reserved.
+ *
+ *   This copyrighted material is made available to anyone wishing
+ *   to use, modify, copy, or redistribute it subject to the terms
+ *   and conditions of the GNU General Public License version 2.
+ *
+ *   This program is distributed in the hope that it will be
+ *   useful, but WITHOUT ANY WARRANTY; without even the implied
+ *   warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ *   PURPOSE. See the GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public
+ *   License along with this program; if not, write to the Free
+ *   Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ *   Boston, MA 02110-1301, USA.
+ *
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ */
 
 package main
 
 import (
 	"database/sql"
-	"fmt"
-	"strings"
-	"regexp"
 	"errors"
-	"sort"
+	"fmt"
 	_ "github.com/lib/pq"
+	"regexp"
+	"sort"
+	"strings"
 )
 
-// Const values for configuration mode field.
+// Const values for configuration Mode field.
 const (
-	PRINT_ALL int	= 1
-	PRINT_SUBSYS	= 2
+	printAll    int = 1
+	printSubsys     = 2
 )
 
 // Sql connection configuration
-type Connect_token struct{
-	Host	string
-	Port	int
-	User	string
-	Pass	string
-	Dbname	string
+type connectToken struct {
+	host   string
+	port   int
+	user   string
+	pass   string
+	DBName string
 }
 
-type Entry struct {
-	Sym_id		int
-	Symbol		string
-	Exported	bool
-	Type		string
-	Subsys		[]string
-	Fn		string
+type entry struct {
+	symID     int
+	symbol    string
+	exported  bool
+	entryType string
+	subSys    []string
+	fn        string
 }
 
-type Edge struct {
-	Caller	int
-	Callee	int
+type edge struct {
+	caller int
+	callee int
 }
 
-type Cache struct {
-	Successors	map[int][]Entry
-	Entries		map[int]Entry
-	SubSys		map[string]string
+type cache struct {
+	successors map[int][]entry
+	entries    map[int]entry
+	subSys     map[string]string
 }
-
 
 // Connects the target db and returns the handle
-func Connect_db(t *Connect_token) (*sql.DB){
-	psqlconn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", (*t).Host, (*t).Port, (*t).User, (*t).Pass, (*t).Dbname)
-	db, err := sql.Open("postgres", psqlconn)
-	if err!= nil {
+func connectDB(t *connectToken) *sql.DB {
+	psqlConn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", (*t).host, (*t).port, (*t).user, (*t).pass, (*t).DBName)
+	db, err := sql.Open("postgres", psqlConn)
+	if err != nil {
 		panic(err)
-		}
+	}
 	return db
 }
 
 // Returns function details from a given id
-func get_entry_by_id(db *sql.DB, symbol_id int, instance int,cache map[int]Entry)(Entry, error){
-	var e		Entry
-	var s		sql.NullString
+func getEntryByID(db *sql.DB, symbol_id int, instance int, cache map[int]entry) (entry, error) {
+	var e entry
+	var s sql.NullString
 
 	if e, ok := cache[symbol_id]; ok {
 		return e, nil
-		}
+	}
 
-	query:="select symbol_id, symbol_name, subsys_name, file_name from "+
-		"(select * from symbols, files where symbols.symbol_file_ref_id=files.file_id and symbols.symbol_instance_id_ref=$2) as dummy "+
+	query := "select symbol_id, symbol_name, subsys_name, file_name from " +
+		"(select * from symbols, files where symbols.symbol_file_ref_id=files.file_id and symbols.symbol_instance_id_ref=$2) as dummy " +
 		"left outer join tags on dummy.symbol_file_ref_id=tags.tag_file_ref_id where symbol_id=$1 and symbol_instance_id_ref=$2"
 	rows, err := db.Query(query, symbol_id, instance)
-	if err!= nil {
+	if err != nil {
 		panic(err)
-		}
+	}
 	defer rows.Close()
 
 	for rows.Next() {
-		if err := rows.Scan(&e.Sym_id, &e.Symbol, &s, &e.Fn); err != nil {
+		if err := rows.Scan(&e.symID, &e.symbol, &s, &e.fn); err != nil {
 			fmt.Println("this error hit3")
 			fmt.Println(err)
 			return e, err
-			}
-		if s.Valid {
-			e.Subsys=append(e.Subsys, s.String)
-			}
 		}
+		if s.Valid {
+			e.subSys = append(e.subSys, s.String)
+		}
+	}
 	if err = rows.Err(); err != nil {
 		fmt.Println("this error hit")
 		return e, err
-		}
-	cache[symbol_id]=e
+	}
+	cache[symbol_id] = e
 	return e, nil
 }
 
 // Returns the list of successors (called function) for a given function
-func get_successors_by_id(db *sql.DB, symbol_id int, instance int, cache Cache )([]Entry, error){
-	var e		Edge
-	var res		[]Entry
+func getSuccessorsByID(db *sql.DB, symbol_id int, instance int, cache cache) ([]entry, error) {
+	var e edge
+	var res []entry
 
-
-	if res, ok := cache.Successors[symbol_id]; ok {
+	if res, ok := cache.successors[symbol_id]; ok {
 		return res, nil
-		}
+	}
 
-	query:="select caller, callee from xrefs where caller =$1 and xref_instance_id_ref=$2"
+	query := "select caller, callee from xrefs where caller =$1 and xref_instance_id_ref=$2"
 	rows, err := db.Query(query, symbol_id, instance)
-	if err!= nil {
+	if err != nil {
 		panic(err)
-		}
+	}
 	defer rows.Close()
 
 	for rows.Next() {
-		if err := rows.Scan(&e.Caller, &e.Callee); err != nil {
+		if err := rows.Scan(&e.caller, &e.callee); err != nil {
 			fmt.Println("this error hit1 ")
 			return nil, err
-			}
-		successors,_ := get_entry_by_id(db, e.Callee, instance, cache.Entries)
-		res=append(res, successors )
 		}
+		successors, _ := getEntryByID(db, e.callee, instance, cache.entries)
+		res = append(res, successors)
+	}
 	if err = rows.Err(); err != nil {
 		fmt.Println("this error hit2 ")
 		return nil, err
-		}
-	cache.Successors[symbol_id]=res
+	}
+	cache.successors[symbol_id] = res
 	return res, nil
 }
 
 // Return id an item is already in the list
-func Not_in(list []int, v int) bool {
+func notIn(list []int, v int) bool {
 
 	for _, a := range list {
 		if a == v {
 			return false
-			}
 		}
+	}
 	return true
 }
 
 // Removes duplicates resulting by the exploration of a call tree
-func removeDuplicate(list []Entry) []Entry {
+func removeDuplicate(list []entry) []entry {
 
-	sort.SliceStable(list, func(i, j int) bool { return list[i].Sym_id < list[j].Sym_id })
+	sort.SliceStable(list, func(i, j int) bool { return list[i].symID < list[j].symID })
 	allKeys := make(map[int]bool)
-	res := []Entry{}
+	res := []entry{}
 	for _, item := range list {
-		if _, value := allKeys[item.Sym_id]; !value {
-			allKeys[item.Sym_id] = true
+		if _, value := allKeys[item.symID]; !value {
+			allKeys[item.symID] = true
 			res = append(res, item)
-			}
 		}
+	}
 	return res
 }
 
 // Given a function returns the lager subsystem it belongs
-func get_subsys_from_symbol_name(db *sql.DB, symbol string, instance int, subsytems_cache map[string]string)(string, error){
+func getSubsysFromSymbolName(db *sql.DB, symbol string, instance int, subsystemsCache map[string]string) (string, error) {
 	var res string
 
-	if res, ok := subsytems_cache[symbol]; ok {
+	if res, ok := subsystemsCache[symbol]; ok {
 		return res, nil
-		}
-	query:="select subsys_name from (select count(*)as cnt, subsys_name from tags where subsys_name in (select subsys_name from symbols, "+
-		"tags where symbols.symbol_file_ref_id=tags.tag_file_ref_id and symbols.symbol_name=$1 and symbols.symbol_instance_id_ref=$2) "+
+	}
+	query := "select subsys_name from (select count(*)as cnt, subsys_name from tags where subsys_name in (select subsys_name from symbols, " +
+		"tags where symbols.symbol_file_ref_id=tags.tag_file_ref_id and symbols.symbol_name=$1 and symbols.symbol_instance_id_ref=$2) " +
 		"group by subsys_name order by cnt desc) as tbl;"
 
 	rows, err := db.Query(query, symbol, instance)
-	if err!= nil {
+	if err != nil {
 		panic(err)
-		}
+	}
 	defer rows.Close()
 
 	for rows.Next() {
 		if err := rows.Scan(&res); err != nil {
 			fmt.Println("this error hit1 ")
 			return "", err
-			}
 		}
-	subsytems_cache[symbol]=res
+	}
+	subsystemsCache[symbol] = res
 	return res, nil
 }
 
 // Returns the id of a given function name
-func sym2num(db *sql.DB, symb string, instance int)(int, error){
-	var 	res	int=0
-	var	cnt 	int=0
-	query:="select symbol_id from symbols where symbols.symbol_name=$1 and symbols.symbol_instance_id_ref=$2"
+func sym2num(db *sql.DB, symb string, instance int) (int, error) {
+	var res int = 0
+	var cnt int = 0
+	query := "select symbol_id from symbols where symbols.symbol_name=$1 and symbols.symbol_instance_id_ref=$2"
 	rows, err := db.Query(query, symb, instance)
-	if err!= nil {
+	if err != nil {
 		panic(err)
-		}
+	}
 	defer rows.Close()
 
 	for rows.Next() {
 		cnt++
-		if err := rows.Scan(&res,); err != nil {
+		if err := rows.Scan(&res); err != nil {
 			fmt.Println("this error hit7")
 			fmt.Println(err)
 			return res, err
-			}
 		}
-	if cnt!=1 {
+	}
+	if cnt != 1 {
 		return res, errors.New("id is not unique")
-		}
+	}
 	return res, nil
 }
 
 // Checks if a given function needs to be explored
-func not_exluded(symbol string, excluded []string)bool{
+func notExcluded(symbol string, excluded []string) bool {
 
-	for _,s:=range excluded{
-		if match,_ :=regexp.MatchString(s, symbol); match{
+	for _, s := range excluded {
+		if match, _ := regexp.MatchString(s, symbol); match {
 			return false
-			}
 		}
+	}
 	return true
 }
 
 // Computes the call tree of a given function name
-func Navigate(db *sql.DB, symbol_id int, parent_dispaly string, visited *[]int, prod map[string]int, instance int, cache Cache, mode int, excluded []string, depth uint, maxdepth uint, dot_fmt string, output *string) {
-	var tmp,s,l,ll,r	string
-	var depthInc		uint	= 0
+func navigate(db *sql.DB, symbol_id int, parentDisplay string, visited *[]int, prod map[string]int, instance int, cache cache, mode int, excluded []string, depth uint, maxDepth uint, dotFmt string, output *string) {
+	var tmp, s, l, ll, r string
+	var depthInc uint = 0
 
-	*visited=append(*visited, symbol_id)
-	l=parent_dispaly
-	successors, err:=get_successors_by_id(db, symbol_id, instance, cache);
-	successors=removeDuplicate(successors)
-	if err==nil {
-		for _, curr := range successors{
-			entry, err := get_entry_by_id(db, curr.Sym_id, instance, cache.Entries)
-			if err!=nil {
-				r="Unknown";
-				} else {
-					r=entry.Symbol
-					}
+	*visited = append(*visited, symbol_id)
+	l = parentDisplay
+	successors, err := getSuccessorsByID(db, symbol_id, instance, cache)
+	successors = removeDuplicate(successors)
+	if err == nil {
+		for _, curr := range successors {
+			entry, err := getEntryByID(db, curr.symID, instance, cache.entries)
+			if err != nil {
+				r = "Unknown"
+			} else {
+				r = entry.symbol
+			}
 			switch mode {
-				case PRINT_ALL:
-					s=fmt.Sprintf(dot_fmt, l, r)
-					ll=r
-					depthInc = 1
-					break
-				case PRINT_SUBSYS:
-					if tmp, err=get_subsys_from_symbol_name(db,r, instance, cache.SubSys); r!=tmp {
-						if tmp != "" {
-							r=tmp
-							} else {
-								r="UNDEFINED SUBSYSTEM"
-								}
-						}
-					if l!=r {
-						s=fmt.Sprintf(dot_fmt, l, r)
-						depthInc = 1
-						} else {
-							s="";
-							}
-					ll=r
-					break
-
+			case printAll:
+				s = fmt.Sprintf(dotFmt, l, r)
+				ll = r
+				depthInc = 1
+				break
+			case printSubsys:
+				if tmp, err = getSubsysFromSymbolName(db, r, instance, cache.subSys); r != tmp {
+					if tmp != "" {
+						r = tmp
+					} else {
+						r = "UNDEFINED SUBSYSTEM"
+					}
 				}
+				if l != r {
+					s = fmt.Sprintf(dotFmt, l, r)
+					depthInc = 1
+				} else {
+					s = ""
+				}
+				ll = r
+				break
+
+			}
 			if _, ok := prod[s]; ok {
 				prod[s]++
-				} else {
-					prod[s]=1
-					if s!="" {
-						(*output)=(*output)+s
-						}
-					}
+			} else {
+				prod[s] = 1
+				if s != "" {
+					(*output) = (*output) + s
+				}
+			}
 
-			if Not_in(*visited, curr.Sym_id){
-				if not_exluded(entry.Symbol, excluded) && (maxdepth == 0 || (maxdepth > 0 && depth < maxdepth)){
-					Navigate(db, curr.Sym_id, ll, visited, prod, instance, cache, mode, excluded, depth+depthInc, maxdepth, dot_fmt, output)
-					}
+			if notIn(*visited, curr.symID) {
+				if notExcluded(entry.symbol, excluded) && (maxDepth == 0 || (maxDepth > 0 && depth < maxDepth)) {
+					navigate(db, curr.symID, ll, visited, prod, instance, cache, mode, excluded, depth+depthInc, maxDepth, dotFmt, output)
 				}
 			}
 		}
+	}
 }
 
 // Returns the subsystem list associated with a given function name
-func symbSubsys(db *sql.DB, symblist []int, instance int, cache Cache,)(string, error){
-	var out	string
-	var res	string
+func symbSubsys(db *sql.DB, symbList []int, instance int, cache cache) (string, error) {
+	var out string
+	var res string
 
-	for _, symbid := range symblist {
-		//resolve sybm
-		symb, _ := get_entry_by_id(db, symbid, instance, cache.Entries)
-		out=out+fmt.Sprintf("{\"FuncName\":\"%s\", \"subsystems\":[", symb.Symbol)
-		query:=fmt.Sprintf("select subsys_name from tags where tag_file_ref_id= (select symbol_file_ref_id from symbols where symbol_id=%d);", symbid)
+	for _, symbID := range symbList {
+		//resolve symb
+		symb, _ := getEntryByID(db, symbID, instance, cache.entries)
+		out = out + fmt.Sprintf("{\"FuncName\":\"%s\", \"subsystems\":[", symb.symbol)
+		query := fmt.Sprintf("select subsys_name from tags where tag_file_ref_id= (select symbol_file_ref_id from symbols where symbol_id=%d);", symbID)
 		rows, err := db.Query(query)
-			if err!= nil {
-				return "", errors.New("symbSubsys query failed")
-				}
+		if err != nil {
+			return "", errors.New("symbSubsys query failed")
+		}
 		defer rows.Close()
 
 		for rows.Next() {
-			if err := rows.Scan(&res,); err != nil {
+			if err := rows.Scan(&res); err != nil {
 				return "", errors.New("symbSubsys query browsing failed")
-				}
-			out=out+fmt.Sprintf("\"%s\",", res)
 			}
-		out=strings.TrimSuffix(out, ",")+"]},"
+			out = out + fmt.Sprintf("\"%s\",", res)
 		}
-	out=strings.TrimSuffix(out, ",")
+		out = strings.TrimSuffix(out, ",") + "]},"
+	}
+	out = strings.TrimSuffix(out, ",")
 	return out, nil
 }

--- a/psql.go
+++ b/psql.go
@@ -255,7 +255,7 @@ func navigate(db *sql.DB, symbol_id int, parentDisplay string, visited *[]int, p
 		for _, curr := range successors {
 			entry, err := getEntryByID(db, curr.symID, instance, cache.entries)
 			if err != nil {
-				r = "Unknown"
+				r = "unknown"
 			} else {
 				r = entry.symbol
 			}
@@ -270,7 +270,7 @@ func navigate(db *sql.DB, symbol_id int, parentDisplay string, visited *[]int, p
 					if tmp != "" {
 						r = tmp
 					} else {
-						r = "UNDEFINED SUBSYSTEM"
+						r = "undefined subsystem"
 					}
 				}
 				if l != r {


### PR DESCRIPTION
Renames functions, vars etc. accroding to Go standards and best practices, and introduces some other style changes.

1. unexported identifiers use camelCase
2. public identifiers use PascalCase
3. outputted errors should be lowercase and not end with a punctuation mark
4. format code using go fmt

Signed-off-by: Veronika Fuxova <vfuxova@redhat.com>