### PR TITLE
Configure linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,106 @@
+run:
+  timeout: 5m
+linters:
+  enable:
+    # region General
+
+    # Add depguard to prevent adding additional dependencies.
+    - depguard
+    # Prevent improper directives in go.mod.
+    - gomoddirectives
+    # Prevent improper nolint directives.
+    - nolintlint
+
+    # endregion
+
+
+    # region Code Quality and Comments
+
+    # Inspect source code for potential security problems. This check has a fairly high false positive rate,
+    # comment with //nolint:gosec where not relevant.
+    - gosec
+    # Replaces deprecated  golint.
+    - revive
+    # Complain about deeply nested if cases.
+    - nestif
+    # Prevent naked returns in long functions.
+    - nakedret
+    # Make Go code more readable.
+    - gocritic
+    # Check for global variables.
+    - gochecknoglobals
+    # Check if comments end in a period. This helps prevent incomplete comment lines, such as half-written sentences.
+    - godot
+    # Complain about comments as these indicate incomplete code.
+    - godox
+    # Keep the cyclomatic complexity of functions to a reasonable level.
+    - gocyclo
+    # Complain about cognitive complexity of functions.
+    - gocognit
+    # Find repeated strings that could be converted into constants.
+    - goconst
+    # Complain about unnecessary type conversions.
+    - unconvert
+    # Complain about unused parameters. These should be replaced with underscores.
+    - unparam
+    # Check for non-ASCII identifiers.
+    - asciicheck
+    # Check for HTTP response body being closed. Sometimes, you may need to disable this using //nolint:bodyclose.
+    - bodyclose
+    # Check for duplicate code. You may want to disable this with //nolint:dupl if the source code is the same, but
+    # legitimately exists for different reasons.
+    - dupl
+    # Check for pointers in loops. This is a typical bug source.
+    - exportloopref
+    # Enforce a reasonable function length of 60 lines or 40 instructions. In very rare cases you may want to disable
+    # this with //nolint:funlen if there is absolutely no way to split the function in question.
+    - funlen
+    # Prevent dogsledding (mass-ignoring return values). This typically indicates missing error handling.
+    - dogsled
+    # Enforce consistent import aliases across all files.
+    - importas
+    # Make package imports always deterministic.
+    - gci
+    # Make code properly formatted.
+    - gofmt
+    # Prevent faulty error checks.
+    - nilerr
+    # Prevent direct error checks that won't work with wrapped errors.
+    - errorlint
+    # Find slice usage that could potentially be preallocated.
+    - prealloc
+    # Check for improper duration handling.
+    - durationcheck
+    # Enforce tests being in the _test package.
+    - testpackage
+    # Check for magic numbers
+    - gomnd
+    # Check that errors returned from external packages are wrapped.
+    - wrapcheck
+
+    # endregion
+linters-settings:
+  depguard:
+    list-type: whitelist
+    include-go-root: false
+    packages:
+      - github.com/lib/pq
+  govet:
+    enable-all: true
+    check-shadowing: false
+    disable:
+      # Do not check  variable shadowing.
+      - shadow
+  stylecheck:
+    checks:
+      - all
+issues:
+  exclude-use-default: false
+  exclude-rules:
+    - linters:
+        - gofmt
+      source: "//"
+    - linters:
+        - gofmt
+        - revive
+      source: "/*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,4 +25,9 @@ rules:
 
 * Follow Go conventions where applicable (e.g. naming using camelCase or PascalCase)
 * Use `go fmt` to format the code 
-* Linting rules TBA
+* To sanity-check your code before submitting a PR, use [golangci-lint](https://golangci-lint.run/)
+```
+golangci-lint run
+```
+The provided `.golangci.yaml` file describes the linting rules that are used in this codebase. If you have
+a good reason to skip a rule, you can add a `//nolint:rule` comment to the line that you want to skip.


### PR DESCRIPTION
Adds .golangci.yaml file that defines linters used used on the codebase

Signed-off-by: Veronika Fuxova <vfuxova@redhat.com>