### PR TITLE
Fixed testing

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -62,8 +62,12 @@ func compareConfigs(c1 configuration, c2 configuration) bool {
 	return res
 }
 
+//func compareConfigs(c1 configuration, c2 configuration) bool {
+//    return true
+//}
+
 // Tests the ability to extract the configuration from command line arguments
-func testConfig(t *testing.T) {
+func TestConfig(t *testing.T) {
 
 	var testConfig configuration = configuration{
 		DBUrl:          "dummy",
@@ -77,7 +81,7 @@ func testConfig(t *testing.T) {
 		ExcludedBefore: []string{"dummy1", "dummy2", "dummy3"},
 		ExcludedAfter:  []string{"dummyA", "dummyB", "dummyC"},
 		MaxDepth:       1234, //0: no limit
-		Jout:           "jsonOutputPlain",
+		Jout:           "JsonOutputPlain",
 		cmdlineNeeds:   map[string]bool{},
 	}
 

--- a/t_files/test1.json
+++ b/t_files/test1.json
@@ -7,7 +7,8 @@
 "Symbol":"dummy",
 "Instance":1234,
 "Mode":1234,
-"Excluded": ["dummy1", "dummy2", "dummy3"],
+"ExcludedBefore": ["dummy1", "dummy2", "dummy3"],
+"ExcludedAfter": ["dummyA", "dummyB", "dummyC"],
 "MaxDepth":1234,
 "Jout": "JsonOutputPlain"
 }


### PR DESCRIPTION
Signed-off-by: Lev Veyde <lveyde@gmail.com>

tests were broken as it was previously returning:

$ go test -v
testing: warning: no tests to run
PASS
ok      nav     0.003s


after this fix we now get:

$ go test -v
=== RUN   TestConfig
--- PASS: TestConfig (0.00s)
PASS
ok      nav     0.003s