### PR TITLE
Added support for multiple RDBMSes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,8 @@ Descr: kernel symbol navigator
 	-s	<v>	Specifies symbol
 	-i	<v>	Specifies instance
 	-f	<v>	Specifies config file
-	-u	<v>	Forces use specified database userid
-	-p	<v>	Forecs use specified password
-	-d	<v>	Forecs use specified DBhost
-	-p	<v>	Forecs use specified DBPort
+	-e	<v>	Forces to use a specified DB Driver (i.e. postgres, mysql or sqlite3)
+	-d	<v>	Forces to use a specified DB DSN
 	-m	<v>	Sets display mode 2=subsystems,1=all
 	-h		This Help
 ```
@@ -60,28 +58,22 @@ Descr: kernel symbol navigator
 ## Sample configuration:
 ```
 {
-"DBURL":"dbs.hqhome163.com",
-"DBPort":5432,
-"DBUser":"alessandro",
-"DBPassword":"<password>",
-"DBTargetDB":"kernel_bin",
-"Symbol":"__arm64_sys_getppid",
-"Instance":1,
-"Mode":1,
-"Excluded": ["rcu_.*", "kmalloc", "kfree"],
-"MaxDepth":0,
-"Jout": "JsonOutputPlain"
+"DBDriver":	"postgres",
+"DBDSN":	"host=dbs.hqhome163.com port=5432 user=alessandro password=<password> dbname=kernel_bin sslmode=disable",
+"Symbol":	"__arm64_sys_getppid",
+"Instance":	1,
+"Mode":		1,
+"Excluded":	["rcu_.*", "kmalloc", "kfree"],
+"MaxDepth":	0,
+"Jout":		"JsonOutputPlain"
 }
 ```
 Configuration is a file containing a JSON serialized conf object
 
 |Field        |description                                                                                                |type    |Default value      |
 |-------------|-----------------------------------------------------------------------------------------------------------|--------|-------------------|
-|DBURL        |Host name ot ip address of the psql instance                                                               |string  |dbs.hqhome163.com  |
-|DBPort       |tcp port where psql instance is listening                                                                  |integer |5432               |
-|DBUser       |Valid username on the psql instance                                                                        |string  |alessandro         |
-|DBPassword   |Valid password on the psql instance                                                                        |string  |<password>         |
-|DBTargetDB   |The identifier for the DB containing symbols                                                               |string  |kernel_bin         |
+|DBDriver     |Name of DB engine driver, i.e. postgres, mysql or sqlite3                                                  |string  |postgres           |
+|DBDSN        |DSN in the engine specific format                                                                          |string  |See Note           |
 |Symbol       |The symbol where start the navigation                                                                      |string  |NULL               |
 |Instance     |The interesting symbols instance identifier                                                                |integer |1                  |
 |Mode         |Mode of plotting: 1 symbols, 2 subsystems, 3 subsystems with labels,4 target subsystem isolation           |integer |2                  |
@@ -89,3 +81,7 @@ Configuration is a file containing a JSON serialized conf object
 |MaxDepth     |Max number of levels to explore 0 no limit                                                                 |integer |0                  |
 |Jout         |Type of output: GraphOnly, JsonOutputPlain, JsonOutputB64, JsonOutputGZB64                                 |enum    |GraphOnly          |
 |Target_sybsys|List of subsys that need to be highlighted. if empty, only the subs that contain the start is highlighted  |string  |[]                 | 
+
+**NOTE:** Currently the default DBDSN value is set to:
+host=dbs.hqhome163.com port=5432 user=alessandro password=<password> dbname=kernel_bin sslmode=disable
+to be consistent with the previous default configuration.

--- a/config.go
+++ b/config.go
@@ -19,8 +19,6 @@ const (
 	appDescr string = "Descr: kernel symbol navigator"
 )
 
-const DBPortNumber = 5432
-
 type argFunc func(*configuration, []string) error
 
 // Command line switch elements.
@@ -36,10 +34,8 @@ type cmdLineItems struct {
 // Represents the application configuration.
 type configuration struct {
 	cmdlineNeeds   map[string]bool
-	DBTargetDB     string
-	DBUrl          string
-	DBUser         string
-	DBPassword     string
+	DBDriver       string
+	DBDSN          string
 	Symbol         string
 	Jout           string
 	ExcludedBefore []string
@@ -48,16 +44,12 @@ type configuration struct {
 	Instance       int
 	MaxDepth       int
 	Mode           outMode
-	DBPort         int
 }
 
 // Instance of default configuration values.
 var defaultConfig = configuration{
-	DBUrl:          "dbs.hqhome163.com",
-	DBPort:         DBPortNumber,
-	DBUser:         "alessandro",
-	DBPassword:     "<password>",
-	DBTargetDB:     "kernel_bin",
+	DBDriver:       "postgres",
+	DBDSN:          "host=dbs.hqhome163.com port=5432 user=alessandro password=<password> dbname=kernel_bin sslmode=disable",
 	Symbol:         "",
 	Instance:       0,
 	Mode:           printSubsys,
@@ -88,10 +80,8 @@ func cmdLineItemInit() []cmdLineItems {
 	pushCmdLineItem("-s", "Specifies symbol", true, true, funcSymbol, &res)
 	pushCmdLineItem("-i", "Specifies instance", true, true, funcInstance, &res)
 	pushCmdLineItem("-f", "Specifies config file", true, false, funcJconf, &res)
-	pushCmdLineItem("-u", "Forces use specified database userid", true, false, funcDBUser, &res)
-	pushCmdLineItem("-p", "Forces use specified password", true, false, funcDBPass, &res)
-	pushCmdLineItem("-d", "Forces use specified DBHost", true, false, funcDBHost, &res)
-	pushCmdLineItem("-p", "Forces use specified DBPort", true, false, funcDBPort, &res)
+	pushCmdLineItem("-e", "Forces to use a specified DB Driver (i.e. postgres, mysql or sqlite3)", true, false, funcDBDriver, &res)
+	pushCmdLineItem("-d", "Forces to use a specified DB DSN", true, false, funcDBDSN, &res)
 	pushCmdLineItem("-m", "Sets display mode 2=subsystems,1=all", true, false, funcMode, &res)
 	pushCmdLineItem("-x", "Specify Max depth in call flow exploration", true, false, funcDepth, &res)
 	pushCmdLineItem("-h", "This help", false, false, funcHelp, &res)
@@ -133,27 +123,13 @@ func funcSymbol(conf *configuration, fn []string) error {
 	return nil
 }
 
-func funcDBUser(conf *configuration, user []string) error {
-	conf.DBUser = user[0]
+func funcDBDriver(conf *configuration, driver []string) error {
+	conf.DBDriver = driver[0]
 	return nil
 }
 
-func funcDBPass(conf *configuration, pass []string) error {
-	conf.DBPassword = pass[0]
-	return nil
-}
-
-func funcDBHost(conf *configuration, host []string) error {
-	conf.DBUrl = host[0]
-	return nil
-}
-
-func funcDBPort(conf *configuration, port []string) error {
-	s, err := strconv.Atoi(port[0])
-	if err != nil {
-		return err
-	}
-	conf.DBPort = s
+func funcDBDSN(conf *configuration, dsn []string) error {
+	conf.DBDSN = dsn[0]
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,7 @@ module nav
 go 1.18
 
 require (
+	github.com/go-sql-driver/mysql v1.7.0 // indirect
 	github.com/lib/pq v1.10.6 // indirect
+	github.com/mattn/go-sqlite3 v1.14.16 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
+github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
+github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/lib/pq v1.10.6 h1:jbk+ZieJ0D7EVGJYpL9QTz7/YW6UHbmdnZWYyK5cdBs=
 github.com/lib/pq v1.10.6/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
+github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/radareorg/r2pipe-go v0.2.1 h1:2bVIi7qHPQCdjjngcJbQO2VHSqPaRBt5LUAMk2uq84o=
 github.com/radareorg/r2pipe-go v0.2.1/go.mod h1:HNUWNjS7SjzhZ7McDLhvIBSOLz1X9DNLjj4J52pAj3Y=

--- a/main_test.go
+++ b/main_test.go
@@ -16,11 +16,8 @@ import (
 func compareConfigs(c1 configuration, c2 configuration) bool {
 
 	res := true
-	res = res && c1.DBUrl == c2.DBUrl
-	res = res && c1.DBPort == c2.DBPort
-	res = res && c1.DBUser == c2.DBUser
-	res = res && c1.DBPassword == c2.DBPassword
-	res = res && c1.DBTargetDB == c2.DBTargetDB
+	res = res && c1.DBDriver == c2.DBDriver
+	res = res && c1.DBDSN == c2.DBDSN
 	res = res && c1.Symbol == c2.Symbol
 	res = res && c1.Instance == c2.Instance
 	res = res && c1.Mode == c2.Mode
@@ -41,11 +38,8 @@ func compareConfigs(c1 configuration, c2 configuration) bool {
 func TestConfig(t *testing.T) {
 
 	var testConfig = configuration{
-		DBUrl:          "dummy",
-		DBPort:         1234,
-		DBUser:         "dummy",
-		DBPassword:     "dummy",
-		DBTargetDB:     "dummy",
+		DBDriver:       "dummy",
+		DBDSN:          "dummy",
 		Symbol:         "dummy",
 		Instance:       1234,
 		Mode:           1234,
@@ -106,8 +100,8 @@ func TestConfig(t *testing.T) {
 	}
 
 	tmp := testConfig
-	tmp.DBUser = "new"
-	os.Args = []string{"nav", "-i", "1", "-s", "symb", "-f", current + "/t_files/test1.json", "-u", "new"}
+	tmp.DBDriver = "new"
+	os.Args = []string{"nav", "-i", "1", "-s", "symb", "-f", current + "/t_files/test1.json", "-e", "new"}
 	conf, err = argsParse(cmdLineItemInit())
 	if err != nil {
 		t.Error("Unexpected conf error while reading from existing file", err, current+"/t_files/test1.json")

--- a/nav.go
+++ b/nav.go
@@ -190,7 +190,7 @@ func main() {
 		fmt.Printf("Unknown mode %s\n", conf.Jout)
 		os.Exit(-2)
 	}
-	t := connectToken{conf.DBUrl, conf.DBPort, conf.DBUser, conf.DBPassword, conf.DBTargetDB}
+	t := connectToken{conf.DBDriver, conf.DBDSN}
 	db := connectDb(&t)
 
 	output, err := generateOutput(db, &conf)

--- a/t_files/test1.json
+++ b/t_files/test1.json
@@ -1,9 +1,6 @@
 {
-"DBURL":"dummy",
-"DBPort":1234,
-"DBUser":"dummy",
-"DBPassword":"dummy",
-"DBTargetDB":"dummy",
+"DBDriver":"dummy",
+"DBDSN":"dummy",
 "Symbol":"dummy",
 "Instance":1234,
 "Mode":1234,


### PR DESCRIPTION
This patch adds support for reading from multiple RDBMS systems, namely MariaDB and SQLite.

That is a complementary patch to the same kind of support that was added to the kern_bin_db part.